### PR TITLE
feat: make extract function structured-only across SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Docuglean is a unified SDK for intelligent document processing using State of th
 ## Features
 - 🚀 **Easy to Use**: Simple, intuitive API with detailed documentation. Just pass in a file and get markdown in response.
 - 🔍 **OCR Capabilities**: Extract text from images and scanned documents
-- 📊 **Structured Data Extraction**: Use Zod schemas for type-safe data extraction
+- 📊 **Structured Data Extraction**: Use Zod/Pydantic schemas for type-safe structured data extraction
 - 📄 **Multimodal Support**: Process PDFs and images with ease
 - 🤖 **Multiple AI Providers**: Support for OpenAI, Mistral, and Google Gemini, with more coming soon
 - 🔒 **Type Safety**: Full TypeScript support with comprehensive types
@@ -30,14 +30,46 @@ npm install docuglean-ocr
 **Repository:** [node-ocr/](./node-ocr/)
 
 **Quick Start:**
+
+**OCR Function - Pure OCR Processing**
+Extracts text from documents and images, returning content and metadata like bounding boxes (provider-dependent).
+
 ```typescript
 import { ocr, extract } from 'docuglean-ocr';
 
-const result = await ocr({
-  filePath: './document.pdf',
-  provider: 'mistral',
-  model: 'mistral-ocr-latest',
+// Extract raw text from documents (supports URLs and local files)
+const ocrResult = await ocr({
+  filePath: 'https://arxiv.org/pdf/2302.12854',
+  provider: 'openai',
+  model: 'gpt-4o-mini',
   apiKey: 'your-api-key'
+});
+```
+
+**Extract Function - Structured Data Extraction**
+Extracts structured data from documents using custom schemas. Requires a response format schema and returns parsed data.
+
+```typescript
+import { z } from 'zod';
+
+// Define schema for structured extraction
+const ReceiptSchema = z.object({
+  date: z.string(),
+  total: z.number(),
+  items: z.array(z.object({
+    name: z.string(),
+    price: z.number()
+  }))
+});
+
+// Extract structured data from documents
+const extractResult = await extract({
+  filePath: './receipt.pdf',
+  provider: 'mistral',
+  model: 'mistral-small-latest',
+  apiKey: 'your-api-key',
+  responseFormat: ReceiptSchema,
+  prompt: 'Extract receipt details including date, total, and items'
 });
 ```
 
@@ -51,14 +83,47 @@ pip install docuglean-ocr
 **Repository:** [python-ocr/](./python-ocr/)
 
 **Quick Start:**
+
+**OCR Function - Pure OCR Processing**
+Extracts text from documents and images, returning content and metadata like bounding boxes (provider-dependent).
+
 ```python
 from docuglean import ocr, extract
 
-result = await ocr(
-    file_path="./document.pdf",
-    provider="mistral",
-    model="mistral-ocr-latest",
+# Extract raw text from documents (supports URLs and local files)
+ocr_result = await ocr(
+    file_path="./test/data/testocr.png",
+    provider="gemini",
+    model="gemini-2.5-flash",
     api_key="your-api-key"
+)
+```
+
+**Extract Function - Structured Data Extraction**
+Extracts structured data from documents using custom schemas. Requires a response format schema and returns parsed data.
+
+```python
+from pydantic import BaseModel
+from typing import List
+
+# Define schema for structured extraction
+class Item(BaseModel):
+    name: str
+    price: float
+
+class Receipt(BaseModel):
+    date: str
+    total: float
+    items: List[Item]
+
+# Extract structured data from documents
+extract_result = await extract(
+    file_path="./receipt.pdf",
+    provider="mistral",
+    model="mistral-small-latest",
+    api_key="your-api-key",
+    response_format=Receipt,
+    prompt="Extract receipt details including date, total, and items"
 )
 ```
 

--- a/node-ocr/src/extract.ts
+++ b/node-ocr/src/extract.ts
@@ -4,11 +4,11 @@ import { processDocExtractionOpenAI } from './providers/openai';
 import { processDocExtractionGemini } from './providers/gemini';
 
 /**
- * Extracts structured or unstructured information from a document using specified provider
- * @param config Extraction configuration including provider, file path, and API key
- * @returns Extracted information either as string or structured data
+ * Extracts structured information from a document using specified provider
+ * @param config Extraction configuration including provider, file path, API key, and response format schema
+ * @returns Structured data according to the provided schema
  */
-export async function extract(config: ExtractConfig): Promise<string | StructuredExtractionResult<BaseStructuredOutput>> {
+export async function extract<T extends BaseStructuredOutput>(config: ExtractConfig): Promise<T> {
   // Default to mistral if no provider specified
   const provider = config.provider || 'mistral';
 
@@ -18,11 +18,13 @@ export async function extract(config: ExtractConfig): Promise<string | Structure
   // Route to correct provider
   switch (provider) {
     case 'mistral':
-      return processDocExtractionMistral(config);
+      const mistralResult = await processDocExtractionMistral(config);
+      return mistralResult.parsed as T;
     case 'openai':
-      return processDocExtractionOpenAI(config);
+      return await processDocExtractionOpenAI(config) as T;
     case 'gemini':
-      return processDocExtractionGemini(config);
+      const geminiResult = await processDocExtractionGemini(config);
+      return geminiResult.parsed as T;
     default:
       throw new Error(`Provider ${provider} not supported yet`);
   }

--- a/node-ocr/src/types.ts
+++ b/node-ocr/src/types.ts
@@ -84,7 +84,7 @@ export interface ExtractConfig {
   provider?: Provider;
   model?: string;
   prompt?: string;
-  responseFormat?: z.ZodType<any>;
+  responseFormat: z.ZodType<any>;
   systemPrompt?: string;
 }
 

--- a/node-ocr/test/extract.test.ts
+++ b/node-ocr/test/extract.test.ts
@@ -3,26 +3,27 @@ import { z } from 'zod';
 
 // Define example schemas for structured extraction
 const Receipt = z.object({
-  date: z.string(),
-  total: z.number(),
+  date: z.string().describe('The date on the receipt'),
+  total: z.number().describe('The total amount on the receipt'),
   items: z.array(z.object({
-    name: z.string(),
-    price: z.number()
+    name: z.string().describe('The name of the item'),
+    price: z.number().describe('The price of the item')
   }))
 });
 
-// 1. Mistral Unstructured PDF Test
-async function testMistralUnstructuredPdf() {
-  console.log('\nTesting Mistral unstructured extraction with PDF URL...');
+// 1. Mistral Structured PDF Test
+async function testMistralStructuredPdf() {
+  console.log('\nTesting Mistral structured extraction with PDF URL...');
   const response = await extract({
     filePath: 'https://arxiv.org/pdf/2302.12854',
     provider: 'mistral',
     model: 'mistral-small-latest',
     apiKey: process.env.MISTRAL_API_KEY!,
-    prompt: 'Summarize the main findings of this research paper.'
+    responseFormat: Receipt,
+    prompt: 'Extract key information from this research paper including title, authors, and main findings.'
   });
 
-  console.log('Mistral Unstructured PDF Result:', response);
+  console.log('Mistral Structured PDF Result:', response);
 }
 
 // 2. Mistral Structured PDF Test (Book -> structured Zod schema)
@@ -38,27 +39,9 @@ async function testMistralStructuredPdfBook() {
     prompt: 'Please extract the receipt details including date, total amount, and itemized list with prices.'
   });
 
-  if (typeof response !== 'string') {
-    console.log('Mistral Structured PDF (Receipt) Result:', {
-      parsed: response.parsed,
-      raw: response.raw
-    });
-  }
+  console.log('Mistral Structured PDF (Receipt) Result:', response);
 }
 
-// 3. OpenAI Unstructured Response Format PDF Test
-async function testOpenAIUnstructuredPdf() {
-  console.log('\nTesting OpenAI unstructured extraction with Local PDF...');
-  const response = await extract({
-    filePath: './test/data/receipt.pdf',
-    provider: 'openai',
-    model: 'gpt-4.1-mini',
-    apiKey: process.env.OPENAI_API_KEY!,
-    prompt: 'Extract and summarize the receipt details.'
-  });
-
-  console.log('OpenAI Unstructured PDF Result:', response);
-}
 
 // 4. OpenAI Structured PDF Test (Receipt)
 async function testOpenAIStructuredPdf() {
@@ -73,26 +56,9 @@ async function testOpenAIStructuredPdf() {
     prompt: 'Please extract the receipt details including date, total amount, and itemized list with prices.'
   });
 
-  console.log('OpenAI Structured PDF (Receipt) Result:', JSON.stringify(response, null, 2));
+  console.log('OpenAI Structured PDF (Receipt) Result:', response);
 }
 
-// 5. Gemini Unstructured PDF Test
-async function testGeminiUnstructuredPdf() {
-  console.log('\nTesting Gemini unstructured extraction with Local PDF...');
-  try {
-    const response = await extract({
-      filePath: './test/data/receipt.pdf',
-      provider: 'gemini',
-      model: 'gemini-2.5-flash',
-      apiKey: process.env.GEMINI_API_KEY!,
-      prompt: 'Extract and summarize the receipt details.'
-    });
-
-    console.log('Gemini Unstructured PDF Result:', response);
-  } catch (error) {
-    console.log('Gemini Unstructured PDF Test:', error);
-  }
-}
 
 // 6. Gemini Structured PDF Test (Receipt)
 async function testGeminiStructuredPdf() {
@@ -108,12 +74,7 @@ async function testGeminiStructuredPdf() {
       prompt: 'Please extract the receipt details including date, total amount, and itemized list with prices.'
     });
 
-    if (typeof response !== 'string') {
-      console.log('Gemini Structured PDF (Receipt) Result:', {
-        parsed: response.parsed,
-        raw: response.raw
-      });
-    }
+    console.log('Gemini Structured PDF (Receipt) Result:', response);
   } catch (error) {
     console.log('Gemini Structured PDF Test:', error);
   }
@@ -123,15 +84,13 @@ async function testGeminiStructuredPdf() {
 export async function runExtractionTests() {
   try {
     // mistral tests
-    await testMistralUnstructuredPdf();
+    await testMistralStructuredPdf();
     await testMistralStructuredPdfBook();
     
     // OpenAI tests
-    await testOpenAIUnstructuredPdf();
     await testOpenAIStructuredPdf();
 
     // Gemini tests
-    await testGeminiUnstructuredPdf();
     await testGeminiStructuredPdf();
   } catch (error) {
     console.error('Extraction Tests failed:', error);

--- a/python-ocr/src/docuglean/extract.py
+++ b/python-ocr/src/docuglean/extract.py
@@ -10,15 +10,15 @@ from .providers.openai import process_doc_extraction_openai
 from .types import ExtractConfig, StructuredExtractionResult, validate_config
 
 
-async def extract(config: ExtractConfig) -> str | StructuredExtractionResult:
+async def extract(config: ExtractConfig) -> StructuredExtractionResult:
     """
-    Extracts structured or unstructured information from a document using specified provider.
+    Extracts structured information from a document using specified provider.
 
     Args:
-        config: Extraction configuration including provider, file path, and API key
+        config: Extraction configuration including provider, file path, API key, and response format schema
 
     Returns:
-        Extracted information either as string or structured data
+        Structured data according to the provided schema
 
     Raises:
         ValueError: If configuration is invalid

--- a/python-ocr/src/docuglean/providers/openai.py
+++ b/python-ocr/src/docuglean/providers/openai.py
@@ -89,7 +89,7 @@ async def process_ocr_openai(config: OCRConfig) -> OpenAIOCRResponse:
         raise Exception("OpenAI OCR failed: Unknown error")
 
 
-async def process_doc_extraction_openai(config: ExtractConfig) -> str | StructuredExtractionResult:
+async def process_doc_extraction_openai(config: ExtractConfig) -> StructuredExtractionResult:
     """
     Process document extraction using OpenAI.
 
@@ -160,33 +160,20 @@ async def process_doc_extraction_openai(config: ExtractConfig) -> str | Structur
             "content": content
         })
 
-        # Check if structured output is requested
-        if config.response_format:
-            # Use structured output with Pydantic schema
-            response = client.responses.parse(
-                model=config.model or "gpt-4o-2024-08-06",
-                input=input_messages,
-                text_format=config.response_format
-            )
+        # Use structured output with Pydantic schema
+        response = client.responses.parse(
+            model=config.model or "gpt-4o-mini",
+            input=input_messages,
+            text_format=config.response_format
+        )
 
-            if not response:
-                raise Exception("No response from OpenAI document extraction")
+        if not response:
+            raise Exception("No response from OpenAI document extraction")
 
-            return StructuredExtractionResult(
-                raw=str(response.output_parsed),  # Convert parsed object to string
-                parsed=response.output_parsed
-            )
-        else:
-            # Regular unstructured output
-            response = client.responses.create(
-                model=config.model or "gpt-4.1",
-                input=input_messages
-            )
-
-            if not response or not response.output_text:
-                raise Exception("No response from OpenAI document extraction")
-
-            return response.output_text
+        return StructuredExtractionResult(
+            raw=str(response.output_parsed),  # Convert parsed object to string
+            parsed=response.output_parsed
+        )
 
     except Exception as error:
         if isinstance(error, Exception):

--- a/python-ocr/src/docuglean/types.py
+++ b/python-ocr/src/docuglean/types.py
@@ -125,7 +125,7 @@ class ExtractConfig(BaseModel):
     provider: Provider | None = None
     model: str | None = None
     prompt: str | None = None
-    response_format: Any | None = Field(alias="responseFormat", default=None)
+    response_format: Any = Field(alias="responseFormat")  # Required for structured extraction
     system_prompt: str | None = Field(alias="systemPrompt", default=None)
 
     model_config = ConfigDict(validate_by_name=True)

--- a/python-ocr/tests/test_extract.py
+++ b/python-ocr/tests/test_extract.py
@@ -30,39 +30,26 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.mark.asyncio
-async def test_mistral_unstructured_pdf_url():
-    """Test Mistral unstructured extraction with PDF URL."""
+async def test_mistral_structured_pdf_url():
+    """Test Mistral structured extraction with PDF URL."""
     config = ExtractConfig(
         file_path=TEST_PDF_URL,
         provider="mistral",
         model="mistral-small-latest",
         api_key=os.getenv("MISTRAL_API_KEY"),
-        prompt="Summarize the main findings of this research paper."
+        response_format=Receipt,
+        prompt="Extract key information from this research paper including title, authors, and main findings."
     )
 
     result = await extract(config)
 
-    assert isinstance(result, str)
-    assert len(result) > 0
-    print(f"URL PDF extraction result: {result[:200]}...")
+    assert hasattr(result, 'raw')
+    assert hasattr(result, 'parsed')
+    assert len(result.raw) > 0
+    print(f"URL PDF extraction result - Raw: {result.raw[:200]}...")
+    print(f"URL PDF extraction result - Parsed: {result.parsed}")
 
 
-@pytest.mark.asyncio
-async def test_mistral_unstructured_local_pdf():
-    """Test Mistral unstructured extraction with local PDF."""
-    config = ExtractConfig(
-        file_path="./tests/data/receipt.pdf",
-        provider="mistral",
-        model="mistral-small-latest",
-        api_key=os.getenv("MISTRAL_API_KEY"),
-        prompt="Extract and summarize the receipt details."
-    )
-
-    result = await extract(config)
-
-    assert isinstance(result, str)
-    assert len(result) > 0
-    print(f"Local PDF extraction result: {result[:200]}...")
 
 
 @pytest.mark.asyncio

--- a/python-ocr/tests/test_huggingface.py
+++ b/python-ocr/tests/test_huggingface.py
@@ -87,20 +87,30 @@ async def test_huggingface_ocr_base64_image():
 
 
 @pytest.mark.asyncio
-async def test_huggingface_extract_unstructured():
-    """Test Hugging Face unstructured extraction."""
+async def test_huggingface_extract_structured():
+    """Test Hugging Face structured extraction."""
+    from pydantic import BaseModel
+    
+    class DocumentInfo(BaseModel):
+        objects: list[str]
+        text: str
+        description: str
+    
     config = ExtractConfig(
         file_path=TEST_IMAGE_URL,
         provider="huggingface",
         model="HuggingFaceTB/SmolVLM-Instruct",
+        response_format=DocumentInfo,
         prompt="Analyze this document and extract key information."
     )
 
     result = await extract(config)
 
-    assert isinstance(result, str)
-    assert len(result) > 0
-    print(f"HuggingFace extraction result: {result[:200]}...")
+    assert hasattr(result, 'raw')
+    assert hasattr(result, 'parsed')
+    assert len(result.raw) > 0
+    print(f"HuggingFace extraction result - Raw: {result.raw[:200]}...")
+    print(f"HuggingFace extraction result - Parsed: {result.parsed}")
 
 
 @pytest.mark.asyncio

--- a/python-ocr/tests/test_openai.py
+++ b/python-ocr/tests/test_openai.py
@@ -72,21 +72,24 @@ async def test_openai_ocr_local_image():
 
 
 @pytest.mark.asyncio
-async def test_openai_extract_unstructured_pdf():
-    """Test OpenAI unstructured extraction with PDF URL."""
+async def test_openai_extract_structured_pdf():
+    """Test OpenAI structured extraction with PDF URL."""
     config = ExtractConfig(
         file_path=TEST_PDF_URL,
         provider="openai",
         model="gpt-5-mini",
         api_key=os.getenv("OPENAI_API_KEY"),
-        prompt="Summarize the key points from this document."
+        response_format=Receipt,
+        prompt="Extract key information from this research paper including title, authors, and main findings."
     )
 
     result = await extract(config)
 
-    assert isinstance(result, str)
-    assert len(result) > 0
-    print(f"OpenAI unstructured extraction result: {result[:200]}...")
+    assert hasattr(result, 'raw')
+    assert hasattr(result, 'parsed')
+    assert len(result.raw) > 0
+    print(f"OpenAI structured extraction result - Raw: {result.raw[:200]}...")
+    print(f"OpenAI structured extraction result - Parsed: {result.parsed}")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Changes

- **Node.js**: Updated extract function to require responseFormat schema, removed unstructured text return
- **Python**: Updated extract function to require response_format schema, removed unstructured text return  
- **Providers**: Updated all providers (Mistral, OpenAI, Gemini, HuggingFace) to only return structured data
- **Tests**: Removed unstructured extract tests, updated remaining tests for structured-only
- **Documentation**: Updated READMEs to reflect structured-only extract function

## Breaking Changes
-  now requires / parameter
-  no longer returns plain text strings, only structured data
- Removes unstructured extraction capability - use  for plain text extraction

## Benefits
- Clear separation:  for text extraction,  for structured data
- Type safety enforced at compile time
- Consistent behavior across all providers