### PR TITLE
feat: add local PDF parsing option (no API calls)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Docuglean is a unified SDK for intelligent document processing using State of th
 - 🤖 **Multiple AI Providers**: Support for OpenAI, Mistral, and Google Gemini, with more coming soon
 - 🔒 **Type Safety**: Full TypeScript support with comprehensive types
 - **summarize**: Get structured TLDRs of long documents
+ - **local OCR (PDF)**: Parse PDFs locally without calling external APIs.
 
 ## Available SDKs
 
@@ -145,8 +146,6 @@ extract_result = await extract(
 ```
 
 ## Coming Soon
-
-- [ ] 🌐 **translate()**: Support for multilingual documents
 - [ ] 🏷️ **classify()**: Document type classifier (receipt, ID, invoice, etc.)
 - [ ] 🤖 **More Models. More Providers**: Integration with Meta's Llama, Together AI, OpenRouter and lots more.
 - [ ] 🌍 **Multilingual**: Support for multiple languages

--- a/node-ocr/README.md
+++ b/node-ocr/README.md
@@ -62,6 +62,14 @@ const mistralResult = await ocr({
   model: 'mistral-ocr-latest',
   apiKey: 'your-api-key'
 });
+
+// Local OCR (no API, PDFs only) using pdf2json
+const localResult = await ocr({
+  filePath: './document.pdf',
+  provider: 'local',
+  apiKey: 'local'
+});
+console.log('Local text:', (localResult as any).text.substring(0, 200) + '...');
 ```
 
 ### Extract Function - Document Analysis & Information Extraction

--- a/node-ocr/package.json
+++ b/node-ocr/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@google/genai": "^1.16.0",
     "@mistralai/mistralai": "^1.6.1",
+    "pdf2json": "^2.0.1",
     "openai": "^4.103.0",
     "zod": "^3.25.30"
   }

--- a/node-ocr/src/ocr.ts
+++ b/node-ocr/src/ocr.ts
@@ -1,7 +1,8 @@
-import { OCRConfig, MistralOCRResponse, OpenAIOCRResponse, GeminiOCRResponse, validateConfig } from './types';
+import { OCRConfig, MistralOCRResponse, OpenAIOCRResponse, GeminiOCRResponse, LocalOCRResponse, validateConfig } from './types';
 import { processOCRMistral } from './providers/mistral';
 import { processOCROpenAI } from './providers/openai';
 import { processOCRGemini } from './providers/gemini';
+import { processOCRLocal } from './providers/local';
 
 /**
  * Processes a document using OCR with specified provider
@@ -9,7 +10,7 @@ import { processOCRGemini } from './providers/gemini';
  * @returns Processed text and metadata
  */
 
-export async function ocr(config: OCRConfig): Promise<MistralOCRResponse | OpenAIOCRResponse | GeminiOCRResponse> {
+export async function ocr(config: OCRConfig): Promise<MistralOCRResponse | OpenAIOCRResponse | GeminiOCRResponse | LocalOCRResponse> {
   // Default to mistral if no provider specified
   const provider = config.provider || 'mistral';
 
@@ -24,6 +25,8 @@ export async function ocr(config: OCRConfig): Promise<MistralOCRResponse | OpenA
       return processOCROpenAI(config);
     case 'gemini':
       return processOCRGemini(config);
+    case 'local':
+      return processOCRLocal(config);
     default:
       throw new Error(`Provider ${provider} not supported yet`);
   }

--- a/node-ocr/src/providers/index.ts
+++ b/node-ocr/src/providers/index.ts
@@ -1,6 +1,7 @@
 import { processOCRMistral } from './mistral';
 import { processOCROpenAI } from './openai';
 import { processOCRGemini } from './gemini';
+import { processOCRLocal } from './local';
 
 export const providers = {
   openai: {
@@ -19,4 +20,6 @@ export const providers = {
 
 
 export { processOCRMistral, processOCROpenAI, processOCRGemini };
+
+export { processOCRLocal };
 

--- a/node-ocr/src/providers/local.ts
+++ b/node-ocr/src/providers/local.ts
@@ -1,0 +1,44 @@
+import fs from 'fs';
+import path from 'path';
+import PDFParser from 'pdf2json';
+import { LocalOCRResponse, OCRConfig } from '../types';
+
+export async function processOCRLocal(config: OCRConfig): Promise<LocalOCRResponse> {
+  const ext = path.extname(config.filePath).toLowerCase();
+  if (ext !== '.pdf') {
+    throw new Error('Local OCR currently supports only local PDF files');
+  }
+  if (config.filePath.startsWith('http://') || config.filePath.startsWith('https://')) {
+    throw new Error('Local OCR requires a local file path');
+  }
+  await fs.promises.access(config.filePath, fs.constants.R_OK);
+
+  return new Promise<LocalOCRResponse>((resolve, reject) => {
+    const pdfParser = new (PDFParser as any)(/* cMap, cMapPack not required here */);
+
+    pdfParser.on('pdfParser_dataError', (errData: any) => reject(new Error(errData.parserError)));
+    pdfParser.on('pdfParser_dataReady', (pdfData: any) => {
+      try {
+        const pages = pdfData?.formImage?.Pages || [];
+        const texts: string[] = [];
+        for (const page of pages) {
+          for (const text of page.Texts || []) {
+            // Each Text contains an array of R (runs) with T (encoded text)
+            for (const run of text.R || []) {
+              const decoded = decodeURIComponent(run.T || '');
+              texts.push(decoded);
+            }
+          }
+          texts.push('\n');
+        }
+        resolve({ text: texts.join(' ') });
+      } catch (e: any) {
+        reject(new Error(`Failed to parse PDF: ${e.message || e}`));
+      }
+    });
+
+    pdfParser.loadPDF(config.filePath);
+  });
+}
+
+

--- a/node-ocr/src/types.ts
+++ b/node-ocr/src/types.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-export type Provider = 'openai' | 'mistral' | 'gemini';
+export type Provider = 'openai' | 'mistral' | 'gemini' | 'local';
 
 export const validateConfig = (config: OCRConfig | ExtractConfig) => {
   if (!config.apiKey?.trim()) {
@@ -8,7 +8,7 @@ export const validateConfig = (config: OCRConfig | ExtractConfig) => {
   if (!config.filePath?.trim()) {
     throw new Error('Valid file path is required');
   }
-  if (config.provider && !['mistral', 'openai', 'gemini'].includes(config.provider)) {
+  if (config.provider && !['mistral', 'openai', 'gemini', 'local'].includes(config.provider)) {
     throw new Error(`Provider ${config.provider} not supported`);
   }
 };
@@ -74,8 +74,16 @@ export interface OCRConfig {
       topP?: number;
       topK?: number;
     };
+    local?: {
+      /** Force local parsing; only PDFs supported */
+      pdf?: boolean;
+    };
   };
   prompt?: string;
+}
+
+export interface LocalOCRResponse {
+  text: string;
 }
 
 export interface ExtractConfig {

--- a/node-ocr/test/ocr.test.ts
+++ b/node-ocr/test/ocr.test.ts
@@ -1,6 +1,6 @@
 import { ocr } from '../src';
 import { handleMistralOCRResponse } from '../src/utils';
-import { MistralOCRResponse, OpenAIOCRResponse, GeminiOCRResponse } from '../src/types';
+import { MistralOCRResponse, OpenAIOCRResponse, GeminiOCRResponse, LocalOCRResponse } from '../src/types';
 
 // 1. Mistral URL Image Test
 async function testMistralUrlImage() {
@@ -212,6 +212,15 @@ export async function runOCRTests() {
     // Gemini Tests
     await testGeminiUrlImage();
     await testGeminiLocalImage();
+
+    // Local parsing test (PDF only)
+    const localResp = await ocr({
+      filePath: './test/data/receipt.pdf',
+      provider: 'local',
+      apiKey: 'local'
+    });
+    const local = localResp as LocalOCRResponse;
+    console.log('Local OCR Result (first 200 chars):', local.text.substring(0, 200) + '...');
   } catch (error) {
     console.error('OCR Tests failed:', error);
     throw error;

--- a/python-ocr/README.md
+++ b/python-ocr/README.md
@@ -48,6 +48,14 @@ result = await ocr(
     model="Qwen/Qwen2.5-VL-3B-Instruct",
     prompt="Extract all text from this image"
 )
+
+# Local OCR (no API, PDFs only) using PyMuPDF
+result = await ocr(
+    file_path="./document.pdf",
+    provider="local",
+    api_key="local"
+)
+print("Local text:", result.text[:200] + "...")
 ```
 
 ### Structured Data Extraction

--- a/python-ocr/pyproject.toml
+++ b/python-ocr/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "mistralai>=0.0.10",
     "pydantic>=2.0.0",
     "transformers>=4.0.0",
+    "pymupdf>=1.26.4",
 ]
 
 [project.optional-dependencies]

--- a/python-ocr/src/docuglean/ocr.py
+++ b/python-ocr/src/docuglean/ocr.py
@@ -7,6 +7,7 @@ from .providers.gemini import process_ocr_gemini
 from .providers.huggingface import process_ocr_huggingface
 from .providers.mistral import process_ocr_mistral
 from .providers.openai import process_ocr_openai
+from .providers.local import process_ocr_local, LocalOCRResponse
 from .types import (
     GeminiOCRResponse,
     HuggingFaceOCRResponse,
@@ -17,7 +18,7 @@ from .types import (
 )
 
 
-async def ocr(config: OCRConfig) -> MistralOCRResponse | OpenAIOCRResponse | HuggingFaceOCRResponse | GeminiOCRResponse:
+async def ocr(config: OCRConfig) -> MistralOCRResponse | OpenAIOCRResponse | HuggingFaceOCRResponse | GeminiOCRResponse | LocalOCRResponse:
     """
     Processes a document using OCR with specified provider.
 
@@ -46,5 +47,7 @@ async def ocr(config: OCRConfig) -> MistralOCRResponse | OpenAIOCRResponse | Hug
         return await process_ocr_huggingface(config)
     elif provider == "gemini":
         return await process_ocr_gemini(config)
+    elif provider == "local":
+        return await process_ocr_local(config.file_path)
     else:
         raise Exception(f"Provider {provider} not supported yet")

--- a/python-ocr/src/docuglean/providers/local.py
+++ b/python-ocr/src/docuglean/providers/local.py
@@ -1,0 +1,37 @@
+"""
+Local OCR provider using PyMuPDF (fitz) for simple text extraction from PDFs.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class LocalOCRResponse:
+    text: str
+
+
+async def process_ocr_local(file_path: str) -> LocalOCRResponse:
+    try:
+        import fitz  # PyMuPDF
+    except Exception as e:  # pragma: no cover
+        raise Exception("PyMuPDF (fitz) is required: pip install pymupdf") from e
+
+    if file_path.startswith("http://") or file_path.startswith("https://"):
+        raise Exception("Local OCR requires a local PDF file path")
+    if not os.path.exists(file_path):
+        raise Exception(f"File not found: {file_path}")
+
+    if not file_path.lower().endswith(".pdf"):
+        raise Exception("Local OCR currently supports only PDF files")
+
+    doc = fitz.open(file_path)
+    texts: list[str] = []
+    for page in doc:
+        texts.append(page.get_text())
+    doc.close()
+    return LocalOCRResponse(text="\n".join(texts))
+
+

--- a/python-ocr/src/docuglean/types.py
+++ b/python-ocr/src/docuglean/types.py
@@ -6,7 +6,7 @@ from typing import Any, Literal, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
-Provider = Literal["openai", "mistral", "huggingface", "gemini"]
+Provider = Literal["openai", "mistral", "huggingface", "gemini", "local"]
 
 
 def validate_config(config: Union["OCRConfig", "ExtractConfig"]) -> None:
@@ -16,7 +16,7 @@ def validate_config(config: Union["OCRConfig", "ExtractConfig"]) -> None:
         raise ValueError("Valid API key is required")
     if not config.file_path or not config.file_path.strip():
         raise ValueError("Valid file path is required")
-    if config.provider and config.provider not in ["mistral", "openai", "huggingface", "gemini"]:
+    if config.provider and config.provider not in ["mistral", "openai", "huggingface", "gemini", "local"]:
         raise ValueError(f"Provider {config.provider} not supported")
 
 

--- a/python-ocr/tests/test_ocr.py
+++ b/python-ocr/tests/test_ocr.py
@@ -57,6 +57,20 @@ async def test_mistral_local_image():
 
 
 @pytest.mark.asyncio
+async def test_local_pdf_parsing():
+    """Test local OCR (PyMuPDF) with local PDF."""
+    result = await ocr(OCRConfig(
+        file_path="./tests/data/receipt.pdf",
+        provider="local",
+        apiKey="local"
+    ))
+    assert hasattr(result, 'text')
+    assert isinstance(result.text, str)
+    assert len(result.text) > 0
+    print(f"Local OCR text: {result.text[:200]}...")
+
+
+@pytest.mark.asyncio
 async def test_mistral_local_pdf():
     """Test Mistral OCR with local PDF."""
     config = OCRConfig(


### PR DESCRIPTION
## Changes

- **Node.js**: Added 'local' provider using pdf2json for PDF text extraction
- **Python**: Added 'local' provider using PyMuPDF for PDF text extraction
- **Dependencies**: Added pdf2json (Node) and pymupdf (Python) to package files
- **Tests**: Added local OCR tests for both SDKs
- **Documentation**: Updated READMEs with local OCR examples

## New Features
-  option for OCR function
- No API keys required for local PDF parsing
- Simple setup - just install dependencies
- PDF-only support (images not supported)

## Benefits
- Offline PDF text extraction
- No external API calls or costs
- Fast local processing
- Simple fallback option for basic PDF parsing